### PR TITLE
make var.source_cidr_blocks optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,7 @@ locals {
 
 # https://www.terraform.io/docs/providers/aws/r/security_group_rule.html
 resource "aws_security_group_rule" "ingress" {
+  count             = length(var.source_cidr_blocks) > 0 ? 1 : 0
   type              = "ingress"
   from_port         = var.port
   to_port           = var.port

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,7 @@ variable "vpc_id" {
 variable "source_cidr_blocks" {
   type        = list(string)
   description = "List of source CIDR blocks."
+  default     = []
 }
 
 variable "engine_version" {


### PR DESCRIPTION
If the user wants to map to a source_security_group_id they can set this
variable to an empty list, and then create their own aws_security_group_rule
outside of the module.

Eg:

```tf
module "redis" {
  source  = "tmknom/elasticache-redis/aws"
  version = "2.0.0"

  name                  = "${local.name}-redis"
  number_cache_clusters = 2
  node_type             = "cache.m3.medium"
  port                  = local.redis_port
  subnet_ids            = local.private_subnets
  vpc_id                = local.vpc_id
  tags                  = local.tags

  # Do not allow connection from arbitrary IPs.
  source_cidr_blocks = []
}

resource "aws_security_group_rule" "redis_ingress" {
  type                     = "ingress"
  from_port                = local.redis_port
  to_port                  = local.redis_port
  protocol                 = "tcp"
  source_security_group_id = module.eks.worker_security_group_id
  security_group_id        = module.redis.security_group_id
}
```