### PR TITLE
Replace deprecated number_cache_clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This module provides recommended settings:
 module "elasticache_redis" {
   source                = "git::https://github.com/tmknom/terraform-aws-elasticache-redis.git?ref=tags/2.0.0"
   name                  = "example"
-  number_cache_clusters = 2
+  num_cache_clusters = 2
   node_type             = "cache.m3.medium"
 
   subnet_ids         = var.subnet_ids
@@ -45,7 +45,7 @@ module "elasticache_redis" {
 module "elasticache_redis" {
   source                = "git::https://github.com/tmknom/terraform-aws-elasticache-redis.git?ref=tags/2.0.0"
   name                  = "example"
-  number_cache_clusters = 2
+  num_cache_clusters = 2
   node_type             = "cache.m3.medium"
 
   engine_version             = "5.0.0"
@@ -95,7 +95,7 @@ module "elasticache_redis" {
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------- | ------------------------ | :------: |
 | name                       | The replication group identifier. This parameter is stored as a lowercase string.                                         | `string`       | n/a                      |   yes    |
 | node_type                  | The compute and memory capacity of the nodes in the node group.                                                           | `string`       | n/a                      |   yes    |
-| number_cache_clusters      | The number of cache clusters (primary and replicas) this replication group will have.                                     | `string`       | n/a                      |   yes    |
+| num_cache_clusters         | The number of cache clusters (primary and replicas) this replication group will have.                                     | `string`       | n/a                      |   yes    |
 | source_cidr_blocks         | List of source CIDR blocks.                                                                                               | `list(string)` | n/a                      |   yes    |
 | subnet_ids                 | List of VPC Subnet IDs for the cache subnet group.                                                                        | `list(string)` | n/a                      |   yes    |
 | vpc_id                     | VPC Id to associate with Redis ElastiCache.                                                                               | `string`       | n/a                      |   yes    |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,7 +1,7 @@
 module "elasticache_redis" {
   source                = "../../"
   name                  = "example"
-  number_cache_clusters = 2
+  num_cache_clusters = 2
   node_type             = "cache.m3.medium"
 
   engine_version             = "5.0.0"

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -1,8 +1,8 @@
 module "elasticache_redis" {
-  source                = "../../"
-  name                  = "example"
+  source             = "../../"
+  name               = "example"
   num_cache_clusters = 2
-  node_type             = "cache.m3.medium"
+  node_type          = "cache.m3.medium"
 
   subnet_ids         = module.vpc.public_subnet_ids
   vpc_id             = module.vpc.vpc_id

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -1,7 +1,7 @@
 module "elasticache_redis" {
   source                = "../../"
   name                  = "example"
-  number_cache_clusters = 2
+  num_cache_clusters = 2
   node_type             = "cache.m3.medium"
 
   subnet_ids         = module.vpc.public_subnet_ids

--- a/main.tf
+++ b/main.tf
@@ -21,9 +21,9 @@ resource "aws_elasticache_replication_group" "default" {
 
   # The number of clusters this replication group initially has.
   # If automatic_failover_enabled is true, the value of this parameter must be at least 2.
-  # The maximum permitted value for number_cache_clusters is 6 (1 primary plus 5 replicas).
+  # The maximum permitted value for num_cache_clusters is 6 (1 primary plus 5 replicas).
   # https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Scaling.RedisReplGrps.html
-  number_cache_clusters = var.number_cache_clusters
+  num_cache_clusters = var.num_cache_clusters
 
   # The compute and memory capacity of the nodes in the node group (shard).
   # Generally speaking, the current generation types provide more memory and computational power at lower cost

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,8 @@ resource "aws_elasticache_replication_group" "default" {
   apply_immediately = var.apply_immediately
 
   # A user-created description for the replication group.
-  replication_group_description = var.description
+  description = var.description
+  # replication_group_description = var.description
 
   # A mapping of tags to assign to the resource.
   tags = merge({ "Name" = var.name }, var.tags)

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "name" {
   description = "The replication group identifier. This parameter is stored as a lowercase string."
 }
 
-variable "number_cache_clusters" {
+variable "num_cache_clusters" {
   type        = string
   description = "The number of cache clusters (primary and replicas) this replication group will have."
 }


### PR DESCRIPTION
+ Number cache cluster is deprecated with AWS provider version 4.15.1
  use num_cache_clusters instead number_cache_clusters ;;